### PR TITLE
Fix projection of geometry

### DIFF
--- a/disaggregator/data.py
+++ b/disaggregator/data.py
@@ -1968,7 +1968,7 @@ def database_shapes():
                       '16-12-31%27&&select=id_ags,gen,geom_as_text,fl_km2')
     geom = [wkt.loads(mp_str) for mp_str in df.geom_as_text]
     return (gpd.GeoDataFrame(df.drop('geom_as_text', axis=1),
-                             crs={'init': 'epsg:3857'}, geometry=geom)
+                             crs={'init': 'epsg:25832'}, geometry=geom)
                .assign(nuts3=lambda x: x.id_ags.map(dict_region_code()))
                .set_index('nuts3').sort_index(axis=0))
 


### PR DESCRIPTION
The geometry of the NUTS regions is loaded in the data module but the wrong projection is set. The projection must be EPSG_25832 and not EPSG_3857.

```diff
- crs={'init': 'epsg:3857'}, geometry=geom)
+ crs={'init': 'epsg:25832'}, geometry=geom)
```

The following should return the bounding box of Germany in degree:

```python
gdf = data.database_shapes()
print(gdf.to_crs("epsg:4326").total_bounds)
```

Before the change you get:
[ 2.51861608 42.4979662   8.27597642 47.96409773]

After the fix:
[ 5.86625035 47.27026501 15.04178941 55.0532603 ]

...which looks more like [Germany](https://gist.github.com/graydon/11198540#file-country-bounding-boxes-py-L45).